### PR TITLE
match expected starting code state for learn ci/cd ch7ass5-custom_cd

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
 </head>
 
 <body class="section">
-    <h1>Welcome to Notely</h1>
+    <h1>Notely</h1>
 
     <div id="userCreationContainer" class="section">
         <input id="nameField" type="text" placeholder="Enter your name">


### PR DESCRIPTION
Assignment instructs the user to:

> Change the `/static/index.html` file so that the `h1` tag says "Welcome to Notely" instead of just "Notely".

However, the tag was accidentally left with the completed contents "Welcome to Notely" out of the box.

In theory, this change could break earlier assignment validations. Did a spot check, and the text "Welcome to Notely" fortunately does not appear in the JSON answers for earlier assignments, so we should be good there.