### PR TITLE
docs(README.md): change port used

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make sure you're on Go version 1.20+.
 Create a `.env` file in the root of the project with the following contents:
 
 ```bash
-PORT="8000"
+PORT="8080"
 ```
 
 Run the server:
@@ -18,6 +18,6 @@ Run the server:
 go build -o notely && ./notely
 ```
 
-*This starts the server in non-database mode.* It will serve a simple webpage at `http://localhost:8000`.
+*This starts the server in non-database mode.* It will serve a simple webpage at `http://localhost:8080`.
 
 You do *not* need to set up a database or any interactivity on the webpage yet. Instructions for that will come later in the course!


### PR DESCRIPTION
Changed the port information because 8000 isn't as fun to say as 8080

boot.dev