### PR TITLE
Adds Windows Docker build script

### DIFF
--- a/scripts/buildprod.ps1
+++ b/scripts/buildprod.ps1
@@ -1,0 +1,1 @@
+$Env:GOOS = "linux"; $Env:CGO_ENABLED = 0; $Env:GOARCH="amd64"; go build -o notely -buildvcs=false


### PR DESCRIPTION
Windows users can use git bash to run `buildprod.sh` but this one just runs natively in pwsh to compile the notely ELF.